### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -45,7 +45,7 @@ class syntax_plugin_datepicker extends DokuWiki_Syntax_Plugin
     /*
      * Handle the matches
      */
-    function handle($match, $state, $pos, Doku_Handler &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 		$mode=trim(substr($match,1,10));
 		$option = trim(substr($match,11,1));
 		//echo $break;
@@ -77,7 +77,7 @@ class syntax_plugin_datepicker extends DokuWiki_Syntax_Plugin
     /*
      * Create output
      */
-    function render($mode, Doku_Renderer &$renderer, $opt) {
+    function render($mode, Doku_Renderer $renderer, $opt) {
 		global $INFO;
 		
 		if($mode == 'metadata') return false;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
